### PR TITLE
チャット入力のEnterキー送信を無効化

### DIFF
--- a/src/features/coach/pages/SessionPage.tsx
+++ b/src/features/coach/pages/SessionPage.tsx
@@ -928,9 +928,6 @@ export default function SessionPage() {
                 onKeyDown={(e) => {
                   if (e.key === 'Enter' && !e.shiftKey) {
                     e.preventDefault();
-                    if (!loopBusy && currentQuestion?.id && answerInput.trim()) {
-                      submitCurrentAnswer(currentQuestion?.id);
-                    }
                   }
                 }}
               />


### PR DESCRIPTION
## Summary
- セッション画面の回答入力でEnterキーを押しても送信されないようにガード
- 送信ボタンを押したときのみ回答を送信する挙動を維持

## Testing
- not run (UI changeのみ)

------
https://chatgpt.com/codex/tasks/task_e_690458ec81b8832b98ff30f98ed1b593