### PR TITLE
Add user registration API and users table

### DIFF
--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -6,6 +6,7 @@ import type {
   ApiError,
   Demographics,
   Turn,
+  User,
 } from "../types/api";
 
 const API_MODE = (import.meta as any).env?.VITE_API_MODE ?? "mock"; // 'mock' | 'real'
@@ -168,6 +169,14 @@ export const api = {
     },
     remove(id: string) {
       return request<{ ok: true }>(`/api/sessions/${id}`, { method: "DELETE" });
+    },
+  },
+  users: {
+    register(payload: { email: string; display_name: string }) {
+      return request<User>("/api/users", {
+        method: "POST",
+        body: JSON.stringify(payload),
+      });
     },
   },
 };

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -141,3 +141,11 @@ export type Turn = {
   content: any;              // { type: 'answer' | 'instruction', ... }
   created_at: string;        // ISO
 };
+
+export type User = {
+  id: string;
+  email: string;
+  display_name: string;
+  created_at: string;
+  updated_at: string;
+};

--- a/supabase/migrations/20251101_add_users_table.sql
+++ b/supabase/migrations/20251101_add_users_table.sql
@@ -1,0 +1,16 @@
+-- users テーブル追加と既存テーブルの外部キー整備
+create table if not exists public.users (
+  id uuid primary key default uuid_generate_v4(),
+  email text not null unique,
+  display_name text not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table if exists public.sessions
+  add constraint sessions_user_id_fkey
+  foreign key (user_id) references public.users(id) on delete set null;
+
+alter table if exists public.strength_profiles
+  add constraint strength_profiles_user_id_fkey
+  foreign key (user_id) references public.users(id) on delete set null;


### PR DESCRIPTION
## Summary
- add a Supabase migration that creates a users table and wires existing user_id columns to it via foreign keys
- expose a POST /api/users endpoint that registers users and optionally allow session creation to link to a user
- surface the new user registration types and client helper on the frontend

## Testing
- npm run typecheck *(fails: missing vite/client and node type definitions in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_6904c4d8df44832ba65e4792f0206ebe