### PR TITLE
Migrate user profile JSON column to explicit fields

### DIFF
--- a/supabase/migrations/20251105_update_users_profile_columns.sql
+++ b/supabase/migrations/20251105_update_users_profile_columns.sql
@@ -1,0 +1,27 @@
+-- Drop legacy JSON column and ensure explicit profile fields exist
+alter table if exists public.users
+  drop column if exists profile_data;
+
+alter table if exists public.users
+  add column if not exists strength_1 text;
+
+alter table if exists public.users
+  add column if not exists strength_2 text;
+
+alter table if exists public.users
+  add column if not exists strength_3 text;
+
+alter table if exists public.users
+  add column if not exists strength_4 text;
+
+alter table if exists public.users
+  add column if not exists strength_5 text;
+
+alter table if exists public.users
+  add column if not exists age text;
+
+alter table if exists public.users
+  add column if not exists gender text;
+
+alter table if exists public.users
+  add column if not exists hometown text;


### PR DESCRIPTION
## Summary
- drop the legacy `profile_data` JSON column and ensure explicit strength/basic info fields exist on users
- update the user registration, login, and profile update APIs to read/write those dedicated columns

## Testing
- npm run test *(fails: optional rollup binary `@rollup/rollup-linux-x64-gnu` missing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_6904edc3b4e4832b839b7d33ed0a8f71